### PR TITLE
feat: add lint composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@ This repository contains several scripts that automate common tasks executed in 
 
 ## How to use
 
+### Lint Python project
+
+Add the following to your workflow:
+
+```yaml
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        id: cache-dependencies
+        with:
+          path: .venv
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ hashFiles('**/Pipfile.lock') }}
+      - name: lint
+        uses: Fondeadora/ci-tools/lint
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+          cache_hit: ${{ steps.cache-dependencies.outputs.cache-hit }}
+```
+
 ### Git consistency
 
 - [Script](bash/git-consistency.sh)
@@ -43,7 +67,7 @@ jobs:
         git checkout ${{ github.head_ref }}
 
     - name: Run git consistency tools
-      env: 
+      env:
         BASE_BRANCH: ${{ github.base_ref }}
         CURRENT_BRANCH: ${{ github.head_ref }}
         REPO_TYPE: "mobile|service" # set to the correct value

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -1,0 +1,39 @@
+name: "Lint"
+description: "Lint a service"
+inputs:
+  access_token:
+    description: "A Github Access Token to download private dependencies"
+    required: true
+  cache_hit:
+    description: "A boolean indicating if there was a cache hit"
+    required: false
+    default: "false"
+  lint_command:
+    description: "The command to run the linter"
+    required: false
+    default: "pipenv run make lint"
+  python_version:
+    description: "Python version to use"
+    required: false
+    default: "3.7.8"
+runs:
+  using: "composite"
+  steps:
+    - name: Add python version to $PATH
+      run: echo "::add-path::/opt/hostedtoolcache/Python/${{ inputs.python_version }}/x64/bin"
+      shell: bash
+    - name: Install pipenv
+      run: pip3.7 install -q pipenv
+      shell: bash
+    - name: Setup Github acces token
+      run: sudo git config --global url."https://${{ inputs.access_token}}@github.com/".insteadOf "ssh://git@github.com/"
+      shell: bash
+    - name: Install dependencies
+      run: |
+        if [ ${{ inputs.cache_hit }} != 'true' ]; then
+          PIPENV_VENV_IN_PROJECT=1 pipenv sync --dev
+        fi
+      shell: bash
+    - name: Run the linter
+      run: ${{ inputs.lint_command }}
+      shell: bash


### PR DESCRIPTION
Closes TBD

### Description

Adds an action to lint our repos.

### What is the current behavior?

We have to copy/paste the current action and repeat a lot of the steps (setup python, download pip, etc)

### What is the new behavior?

We add an action to lint the repos. It takes an `access_token` to download private dependencies from Github, `cache_hit` to know if it has to install the dependencies and optionally a `lint_command` (the default value is `pipenv run make lint`). This way we just need to replace our lint step with something like:

```yaml
      - name: lint the service
        uses: Fondeadora/ci-tools/lint@master
        with:
          access_token: ${{ secrets.ACCESS_TOKEN }}
          cache_hit: ${{ steps.cache-dependencies.outputs.cache-hit == 'true' }}
```

### How was it tested?

We used a branch in the `notificacion-service` repository to try out this action.  

### Checklist

<!-- Please delete options that are not relevant. -->

- [x] Does your code follow the project style guide?
- [ ] Have you updated the documentation as needed?

### Additional Context

N/A