### PR TITLE
feat: bump default python to 3.7.9

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -15,7 +15,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.8"
+    default: "3.7.9"
 runs:
   using: "composite"
   steps:

--- a/serverless-deploy/action.yml
+++ b/serverless-deploy/action.yml
@@ -25,7 +25,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.8"
+    default: "3.7.9"
 runs:
   using: "composite"
   steps:

--- a/test/action.yml
+++ b/test/action.yml
@@ -19,7 +19,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.8"
+    default: "3.7.9"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Closes Fondeadora/fondeadora#1323

### Description

Bumps defualt `python_version` to 3.7.9 

### What is the current behavior?

The actions fail because the github instance was updated [here](https://github.com/actions/virtual-environments/commit/397c0dc73eed4082d2e58686ec2d8bf75014cbaa#diff-43bac3def16599ef5b79ea8b7d9e0a9aR345) to the latest 3.7 python.

### What is the new behavior?

The default version was bumped to 3.7.9

### How was it tested?

N/A

### Checklist

- [x] Does your code follow the project style guide?
- [ ] Have you updated the documentation as needed?

### Additional Context

N/A