### PR TITLE
feat: update env variables setup to the new workflow commands

### DIFF
--- a/common/python-setup.sh
+++ b/common/python-setup.sh
@@ -1,3 +1,3 @@
 export PATH="/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/bin:$PATH"
 pip3.7 install -q pipenv
-echo "::add-path::/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/bin"
+echo "/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/bin" >> $GITHUB_PATH

--- a/serverless-deploy/action.yml
+++ b/serverless-deploy/action.yml
@@ -40,11 +40,16 @@ runs:
       run: ${{ github.action_path }}/../common/install-node-deps.sh
       shell: bash
     - name: Setup AWS credentials
+      env:
+        AWS_ACCESS_KEY_ID: ${{ inputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.aws-secret-access-key }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+        AWS_REGION: ${{ inputs.aws-region }}
       run: |
-        echo "::set-env name=AWS_ACCESS_KEY_ID::${{ inputs.aws-access-key-id }}"
-        echo "::set-env name=AWS_SECRET_ACCESS_KEY::${{ inputs.aws-secret-access-key }}"
-        echo "::set-env name=AWS_DEFAULT_REGION::${{ inputs.aws-region }}"
-        echo "::set-env name=AWS_REGION::${{ inputs.aws-region }}"
+        echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" >> $GITHUB_ENV
+        echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" >> $GITHUB_ENV
+        echo "AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION" >> $GITHUB_ENV
+        echo "AWS_REGION=$AWS_REGION" >> $GITHUB_ENV        
       shell: bash
     - name: Deploy to the desired stage
       run: npx sls deploy -s ${{ inputs.stage }}


### PR DESCRIPTION
Closes Fondeadora/fondeadora#1624

### Description

Updates the env vars and path setup for the Github Actions common actions.

### What is the current behavior?

The common actions use the now deprecated `set-env` and `add-path`.

### What is the new behavior?

We use the new workflow commands `echo "{name}={value}" >> $GITHUB_ENV` y `echo "{path}" >> $GITHUB_PATH`

### How was it tested?

N/A

### Checklist

- [x] Does your code follow the project style guide?

### Additional Context

N/A