### PR TITLE
fix: fix serverless deployment action

### DIFF
--- a/common/install-node-deps.sh
+++ b/common/install-node-deps.sh
@@ -1,3 +1,3 @@
 if [ $CACHE_HIT != 'true' ]; then
-    npm install
+    npm ci
 fi

--- a/serverless-deploy/action.yml
+++ b/serverless-deploy/action.yml
@@ -59,5 +59,5 @@ runs:
         echo "region = $AWS_REGION" >> ~/.aws/credentials  
       shell: bash
     - name: Deploy to the desired stage
-      run: AWS_SDK_LOAD_CONFIG=1 npx sls deploy --stack ${{ inputs.aws-profile }}
+      run: AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stack ${{ inputs.aws-profile }}
       shell: bash


### PR DESCRIPTION
Closes Fondeadora/fondeadora#2215

### Description

Fixes the serverless deployment command.

### What is the current behavior?

Serverless deployments fail when executed on Github Actions and the serverless dependency is not included in the `package.json` file.

### What is the new behavior?

We've updated the npm dependencies command to `npm ci` which does not update the `package-lock.json` ([here](https://medium.com/better-programming/npm-ci-vs-npm-install-which-should-you-use-in-your-node-js-projects-51e07cb71e26)is a comparison).

Also, we've updated the command from `npx sls` to `npm serverless` to really execute serverless commands.

### How was it tested?

- [ ] ✋ 

### Checklist

- [x] Does your code follow the project style guide?
- [ ] Have you updated the documentation as needed?

### Additional Context

N/A