### PR TITLE
fix: python default versioning

### DIFF
--- a/common/python-setup.sh
+++ b/common/python-setup.sh
@@ -1,3 +1,5 @@
-export PATH="/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/bin:$PATH"
+for VERSION in "/opt/hostedtoolcache/Python/$PYTHON_VERSION"*; do
+    export PATH="$VERSION/x64/bin:$PATH"
+    echo "$VERSION/x64/bin" >> $GITHUB_PATH
+done
 pip3.7 install -q pipenv
-echo "/opt/hostedtoolcache/Python/$PYTHON_VERSION/x64/bin" >> $GITHUB_PATH

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -15,7 +15,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.9"
+    default: "3.7"
 runs:
   using: "composite"
   steps:

--- a/serverless-deploy/action.yml
+++ b/serverless-deploy/action.yml
@@ -25,7 +25,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.9"
+    default: "3.7"
   aws-profile:
     description: "The stack to be deployed"
     required: true

--- a/test/action.yml
+++ b/test/action.yml
@@ -19,7 +19,7 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.7.9"
+    default: "3.7"
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
Closes Fondeadora/fondeadora#2225

### Description
Ubuntu runner version update python from python3.7.9 to 3.7.10, this cause all actions from this repo failed.

### What is the current behavior?
- Specify python version with patch

### What is the new behavior?
- Specify python version with minor

### How was it tested?
- [X] github actions

### Checklist

<!-- Please delete options that are not relevant. -->

- [ ] Does your code follow the project style guide?
- [ ] Have you updated the documentation as needed?
- [ ] Have you added tests that cover the changes and run them?

### Additional Context

<!-- Add here any additional context you think is important. -->
