### PR TITLE
ci: use pip3 default

### DIFF
--- a/common/python-setup.sh
+++ b/common/python-setup.sh
@@ -2,4 +2,4 @@ for VERSION in "/opt/hostedtoolcache/Python/$PYTHON_VERSION"*; do
     export PATH="$VERSION/x64/bin:$PATH"
     echo "$VERSION/x64/bin" >> $GITHUB_PATH
 done
-pip3.7 install -q pipenv
+pip3 install -q pipenv


### PR DESCRIPTION
Closes #18 

### Description

No se pueden correr los actions con una version diferente de python.

### What is the current behavior?

python_setup.sh levanta un error.

### What is the new behavior?

Se reemplaza pip3.7 por pip3.

### How was it tested?

:hand: